### PR TITLE
Scaffold auditor prototype with orchestrator and shell agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+blobs/
+events.log

--- a/auditor/agent/interface.py
+++ b/auditor/agent/interface.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+"""Request/response models exchanged between the orchestrator and agent."""
+
+from typing import List, Optional
+from pydantic import BaseModel, Field
+
+
+class Slice(BaseModel):
+    start: int
+    end: int
+
+
+class PlanItem(BaseModel):
+    why: Optional[str] = None
+    cmd: Optional[str] = None
+    read_file: Optional[str] = None
+    slice: Optional[Slice] = None
+
+
+class RetrievalRequest(BaseModel):
+    kind: str = "RETRIEVE"
+    objective: str
+    context: dict
+    plan: List[PlanItem]
+    limits: dict
+
+
+class Span(BaseModel):
+    file: str
+    start_line: Optional[int] = None
+    end_line: Optional[int] = None
+    snippet: Optional[str] = None
+
+
+class Artifact(BaseModel):
+    kind: str
+    sha256: str
+    bytes: int
+    note: Optional[str] = None
+
+
+class RetrievalResponse(BaseModel):
+    result_type: str = "RETRIEVAL_RESULT"
+    spans: List[Span] = Field(default_factory=list)
+    artifacts: List[Artifact] = Field(default_factory=list)
+    notes: List[str] = Field(default_factory=list)

--- a/auditor/agent/shell_agent.py
+++ b/auditor/agent/shell_agent.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+"""Shell based retrieval agent."""
+
+import asyncio
+from pathlib import Path
+from typing import List
+
+from .interface import Artifact, PlanItem, RetrievalRequest, RetrievalResponse, Span
+from auditor.core.storage import BlobStore
+
+
+async def run(request: RetrievalRequest, blobs: BlobStore) -> RetrievalResponse:
+    """Execute a retrieval request and return raw artifacts.
+
+    The agent intentionally performs no interpretation of results.  It
+    simply executes commands and reads files, returning their raw
+    outputs.
+    """
+
+    repo_root = Path(request.context.get("repo_root", "."))
+    spans: List[Span] = []
+    artifacts: List[Artifact] = []
+
+    for item in request.plan:
+        if item.cmd:
+            proc = await asyncio.create_subprocess_shell(
+                item.cmd,
+                cwd=repo_root,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.STDOUT,
+            )
+            out, _ = await proc.communicate()
+            digest = blobs.put(out)
+            artifacts.append(
+                Artifact(kind="stdout", sha256=digest, bytes=len(out), note=item.why)
+            )
+        if item.read_file:
+            path = repo_root / item.read_file
+            text = path.read_text(encoding="utf-8")
+            start = end = None
+            if item.slice:
+                start = item.slice.start
+                end = item.slice.end
+                lines = text.splitlines()
+                snippet = "\n".join(lines[start - 1 : end])
+            else:
+                snippet = text
+            spans.append(
+                Span(
+                    file=item.read_file,
+                    start_line=start,
+                    end_line=end,
+                    snippet=snippet,
+                )
+            )
+
+    return RetrievalResponse(spans=spans, artifacts=artifacts)

--- a/auditor/cli/main.py
+++ b/auditor/cli/main.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+"""Command line interface for the auditor prototype."""
+
+import argparse
+import asyncio
+from pathlib import Path
+
+from auditor.agent import shell_agent
+from auditor.core.models import Condition, Finding
+from auditor.core.orchestrator import Orchestrator
+from auditor.core.storage import BlobStore, EventLog
+from auditor.report.render import render_report
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run auditor prototype")
+    parser.add_argument("--repo", default=".", help="Path to repository root")
+    args = parser.parse_args()
+
+    blob_store = BlobStore(Path("blobs"))
+    event_log = EventLog(Path("events.log"))
+    orch = Orchestrator(blob_store, event_log, shell_agent.run)
+
+    # For now we seed with a single dummy finding and condition.
+    finding = Finding(claim="placeholder", origin_file="")
+    finding.root_conditions.append(Condition(text="stub"))
+
+    report = asyncio.run(orch.run([finding]))
+    print(render_report(report))
+
+
+if __name__ == "__main__":  # pragma: no cover - entry point
+    main()

--- a/auditor/core/models.py
+++ b/auditor/core/models.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+"""Core data models for auditor.
+
+These dataclasses implement the minimal schema described in the
+architectural notes.  They intentionally avoid behaviour in order to
+keep them easy to serialize and reason about.
+"""
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Dict, List, Optional
+
+
+class Status(str, Enum):
+    """Tri-state condition status used by the orchestrator."""
+
+    UNKNOWN = "UNKNOWN"
+    SATISFIED = "SATISFIED"
+    VIOLATED = "VIOLATED"
+
+
+@dataclass
+class CodeSpan:
+    """Reference to a region of code in a file."""
+
+    file: str
+    start_line: Optional[int] = None
+    end_line: Optional[int] = None
+    symbol: Optional[str] = None
+    snippet: Optional[str] = None
+
+
+@dataclass
+class ArtifactRef:
+    """Reference to a stored artifact in the blob store."""
+
+    kind: str
+    sha256: str
+    bytes: int
+    note: Optional[str] = None
+
+
+@dataclass
+class Evidence:
+    """Evidence collected by the retrieval agent."""
+
+    summary: str
+    locations: List[CodeSpan] = field(default_factory=list)
+    artifacts: List[ArtifactRef] = field(default_factory=list)
+    source: str = "agent://retrieval"
+
+
+@dataclass
+class Condition:
+    """Condition that needs to be validated for a finding."""
+
+    text: str
+    plan_params: Dict[str, object] = field(default_factory=dict)
+
+
+@dataclass
+class Finding:
+    """Top level finding derived from a seed file."""
+
+    claim: str
+    origin_file: str
+    root_conditions: List[Condition] = field(default_factory=list)
+
+
+@dataclass
+class AuditReport:
+    """Final report emitted by the orchestrator."""
+
+    findings: List[Finding]
+    started_at: float
+    finished_at: float
+    meta: Dict[str, object] = field(default_factory=dict)

--- a/auditor/core/orchestrator.py
+++ b/auditor/core/orchestrator.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+"""Minimal orchestrator coordinating retrieval tasks."""
+
+import asyncio
+import time
+from dataclasses import dataclass
+from typing import Awaitable, Callable, Deque, List, Tuple
+from collections import deque
+
+from auditor.core.models import AuditReport, Condition, Evidence, Finding, Status
+from auditor.core.storage import BlobStore, EventLog
+from auditor.agent.interface import PlanItem, RetrievalRequest, RetrievalResponse
+
+
+@dataclass
+class Orchestrator:
+    blob_store: BlobStore
+    events: EventLog
+    agent_run: Callable[[RetrievalRequest, BlobStore], Awaitable[RetrievalResponse]]
+    max_depth: int = 1
+    max_children: int = 0
+
+    async def run(self, findings: List[Finding]) -> AuditReport:
+        started = time.time()
+        queue: Deque[Tuple[Finding, Condition, int, List[str]]] = deque()
+        for f in findings:
+            for idx, cond in enumerate(f.root_conditions):
+                queue.append((f, cond, 0, [f"root[{idx}]"]))
+                self.events.emit(
+                    "TASK_ENQUEUED", {"finding": f.claim, "path": [f"root[{idx}]"], "depth": 0}
+                )
+
+        while queue:
+            finding, cond, depth, path = queue.popleft()
+            plan = self.make_plan(finding, cond, depth)
+            req = RetrievalRequest(
+                objective="Collect evidence for condition",
+                context={
+                    "repo_root": ".",
+                    "finding": finding.__dict__,
+                    "condition": cond.__dict__,
+                    "depth": depth,
+                },
+                plan=plan,
+                limits={},
+            )
+            self.events.emit("TASK_STARTED", {"path": path, "depth": depth})
+            res = await self.agent_run(req, self.blob_store)
+            evidence = self.evidence_from(res)
+            status, children = self.decide(cond, evidence)
+            self.events.emit(
+                "NODE_STATUS",
+                {
+                    "path": path,
+                    "status": status.value,
+                },
+            )
+            self.events.emit("TASK_FINISHED", {"path": path})
+            if depth + 1 <= self.max_depth:
+                for i, child in enumerate(children[: self.max_children]):
+                    queue.append((finding, child, depth + 1, path + [f"child[{i}]"]))
+                    self.events.emit(
+                        "TASK_ENQUEUED",
+                        {
+                            "path": path + [f"child[{i}]"]
+                        },
+                    )
+
+        finished = time.time()
+        return AuditReport(findings=findings, started_at=started, finished_at=finished, meta={})
+
+    # --- helpers -------------------------------------------------------
+    def make_plan(self, finding: Finding, condition: Condition, depth: int) -> List[PlanItem]:
+        return []
+
+    def evidence_from(self, res: RetrievalResponse) -> Evidence:
+        return Evidence(summary="", locations=[], artifacts=[])
+
+    def decide(self, cond: Condition, evidence: Evidence) -> Tuple[Status, List[Condition]]:
+        return Status.UNKNOWN, []

--- a/auditor/core/storage.py
+++ b/auditor/core/storage.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+"""Storage helpers for events and blobs.
+
+The event log is a very small newline-delimited JSON file that records
+all actions performed by the orchestrator.  The blob store keeps raw
+artifacts referenced from the log.
+"""
+
+from dataclasses import dataclass
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict
+import hashlib
+
+
+@dataclass
+class EventLog:
+    """Append-only JSON-lines event log."""
+
+    path: Path
+
+    def emit(self, event_type: str, data: Dict[str, Any]) -> None:
+        record = {"type": event_type, **data}
+        with self.path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(record, sort_keys=True) + "\n")
+
+
+@dataclass
+class BlobStore:
+    """Simple content-addressed storage."""
+
+    root: Path
+
+    def __post_init__(self) -> None:
+        self.root.mkdir(parents=True, exist_ok=True)
+
+    def put(self, data: bytes) -> str:
+        digest = hashlib.sha256(data).hexdigest()
+        (self.root / digest).write_bytes(data)
+        return digest
+
+    def get(self, digest: str) -> bytes:
+        return (self.root / digest).read_bytes()

--- a/auditor/report/render.py
+++ b/auditor/report/render.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+"""Helpers to render audit reports."""
+
+from typing import List
+from auditor.core.models import AuditReport
+
+
+def render_report(report: AuditReport) -> str:
+    lines: List[str] = ["# Audit Report"]
+    for idx, finding in enumerate(report.findings, 1):
+        lines.append(f"## Finding {idx}: {finding.claim}")
+        lines.append(f"Origin: {finding.origin_file}")
+        for cond in finding.root_conditions:
+            lines.append(f"- {cond.text}")
+    return "\n".join(lines) + "\n"


### PR DESCRIPTION
## Summary
- define core datamodels and storage helpers for events and blobs
- add Pydantic request/response models and a shell-based retrieval agent
- introduce orchestrator skeleton with report rendering and CLI stub

## Testing
- `python -m py_compile $(find auditor -name '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6897ebfbd29083248ab2d0e22f1bfa85