### PR TITLE
Add root CLI entry point for auditor

### DIFF
--- a/auditor/__init__.py
+++ b/auditor/__init__.py
@@ -1,0 +1,3 @@
+"""Top-level package for auditor."""
+
+# This file allows the `auditor` directory to be imported as a package.

--- a/main.py
+++ b/main.py
@@ -1,0 +1,7 @@
+"""Entry point for running the auditor prototype from the repo root."""
+
+from auditor.cli.main import main
+
+
+if __name__ == "__main__":  # pragma: no cover - convenience script
+    main()


### PR DESCRIPTION
## Summary
- Allow importing auditor as package by adding __init__
- Provide root-level `main.py` to launch auditor CLI without import errors

## Testing
- `python -m pytest -q`
- `python main.py`


------
https://chatgpt.com/codex/tasks/task_e_6897f29184788324a2d651206b5e83d4