### PR TITLE
Implement child-condition discovery with parent context

### DIFF
--- a/auditor/agent/interface.py
+++ b/auditor/agent/interface.py
@@ -1,5 +1,5 @@
-from pydantic import BaseModel
-from typing import Dict, Any
+from pydantic import BaseModel, Field
+from typing import Any, Dict, List
 
 
 class NLRequest(BaseModel):
@@ -11,3 +11,4 @@ class NLRequest(BaseModel):
 
 class NLResponse(BaseModel):
     final: str
+    children: List[Dict[str, Any]] = Field(default_factory=list)

--- a/auditor/cli/main.py
+++ b/auditor/cli/main.py
@@ -12,9 +12,10 @@ from auditor.report.render import render_report
 def main() -> None:
     parser = argparse.ArgumentParser(description="Run auditor prototype")
     parser.add_argument("--repo", default=".", help="Path to repository root")
-    parser.parse_args()
+    parser.add_argument("--discover-depth", type=int, default=0, help="Depth for discovery phase")
+    args = parser.parse_args()
 
-    orch = Orchestrator(shell_agent.run)
+    orch = Orchestrator(shell_agent.run, discover_depth=args.discover_depth)
 
     finding = Finding(claim="placeholder", origin_file="")
     finding.root_conditions.append(Condition(text="stub"))

--- a/auditor/core/models.py
+++ b/auditor/core/models.py
@@ -2,7 +2,8 @@
 
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Dict, List
+import uuid
+from typing import Dict, List, Optional
 
 
 class Status(str, Enum):
@@ -19,6 +20,9 @@ class Condition:
 
     text: str
     plan_params: Dict[str, object] = field(default_factory=dict)
+    children: List["Condition"] = field(default_factory=list)
+    id: str = field(default_factory=lambda: uuid.uuid4().hex)
+    parent_id: Optional[str] = None
 
 
 @dataclass

--- a/auditor/core/orchestrator.py
+++ b/auditor/core/orchestrator.py
@@ -1,11 +1,12 @@
 """Minimal orchestrator coordinating NL requests."""
 
 import time
+import dataclasses
 from dataclasses import dataclass
-from typing import Awaitable, Callable, List
+from typing import Awaitable, Callable, List, Tuple
 
 from auditor.agent.interface import NLRequest, NLResponse
-from auditor.core.models import AuditReport, Finding, Status
+from auditor.core.models import AuditReport, Condition, Finding, Status
 
 
 def _status_from(text: str) -> Status:
@@ -17,21 +18,82 @@ def _status_from(text: str) -> Status:
     return Status.UNKNOWN
 
 
+def _to_dict(obj):
+    return dataclasses.asdict(obj)
+
+
+def _conditions_without_children(f: Finding) -> List[Tuple[Condition, List[Condition]]]:
+    result: List[Tuple[Condition, List[Condition]]] = []
+
+    def visit(cond: Condition, ancestors: List[Condition]) -> None:
+        if not cond.children:
+            result.append((cond, ancestors))
+        else:
+            for child in cond.children:
+                visit(child, ancestors + [cond])
+
+    for root in f.root_conditions:
+        visit(root, [])
+    return result
+
+
+def _walk_all_conditions(f: Finding) -> List[Tuple[Condition, List[Condition]]]:
+    result: List[Tuple[Condition, List[Condition]]] = []
+
+    def visit(cond: Condition, ancestors: List[Condition]) -> None:
+        result.append((cond, ancestors))
+        for child in cond.children:
+            visit(child, ancestors + [cond])
+
+    for root in f.root_conditions:
+        visit(root, [])
+    return result
+
+
 @dataclass
 class Orchestrator:
     agent_run: Callable[[NLRequest], Awaitable[NLResponse]]
+    discover_depth: int = 0
 
     async def run(self, findings: List[Finding]) -> AuditReport:
         started = time.time()
+        if self.discover_depth > 0:
+            await self._discover(findings, self.discover_depth)
+        await self._validate(findings)
+        finished = time.time()
+        return AuditReport(findings=findings, started_at=started, finished_at=finished)
+
+    async def _discover(self, findings: List[Finding], depth: int) -> None:
+        for _ in range(depth):
+            for f in findings:
+                for cond, ancestors in _conditions_without_children(f):
+                    req = NLRequest(
+                        kind="DISCOVER",
+                        objective=f"Expand: {cond.text}",
+                        context={
+                            "finding": _to_dict(f),
+                            "parent_condition": _to_dict(cond),
+                            "ancestors": [_to_dict(a) for a in ancestors],
+                        },
+                    )
+                    res: NLResponse = await self.agent_run(req)
+                    for child_spec in res.children:
+                        child = Condition(text=child_spec.get("text", ""), parent_id=cond.id)
+                        cond.children.append(child)
+
+    async def _validate(self, findings: List[Finding]) -> None:
         for f in findings:
-            for cond in f.root_conditions:
+            for cond, ancestors in _walk_all_conditions(f):
                 req = NLRequest(
+                    kind="RETRIEVE",
                     objective=f"Validate: {cond.text}",
-                    context={"finding": f.__dict__, "condition": cond.__dict__},
+                    context={
+                        "finding": _to_dict(f),
+                        "condition": _to_dict(cond),
+                        "ancestors": [_to_dict(a) for a in ancestors],
+                    },
                 )
                 res: NLResponse = await self.agent_run(req)
                 status = _status_from(res.final)
                 cond.plan_params["status"] = status.value
                 cond.plan_params["final"] = res.final
-        finished = time.time()
-        return AuditReport(findings=findings, started_at=started, finished_at=finished)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+# Ensure project root is on sys.path for imports
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1,0 +1,63 @@
+import asyncio
+
+from auditor.agent.interface import NLRequest, NLResponse
+from auditor.core.models import Condition, Finding
+from auditor.core.orchestrator import Orchestrator
+
+
+def test_discovery_creates_children_and_parent_context():
+    requests = []
+
+    async def agent(req: NLRequest) -> NLResponse:
+        requests.append(req)
+        if req.kind == "DISCOVER":
+            parent_text = req.context["parent_condition"]["text"]
+            return NLResponse(final="", children=[{"text": f"{parent_text}.child"}])
+        return NLResponse(final="PASS: ok")
+
+    orch = Orchestrator(agent, discover_depth=1)
+    finding = Finding(claim="claim", origin_file="orig")
+    finding.root_conditions.append(Condition(text="root"))
+
+    asyncio.run(orch.run([finding]))
+
+    root = finding.root_conditions[0]
+    assert root.children and root.children[0].text == "root.child"
+
+    child = root.children[0]
+    assert child.plan_params["status"] == "SATISFIED"
+    assert "PASS" in child.plan_params["final"]
+
+    disc_req = next(r for r in requests if r.kind == "DISCOVER")
+    assert disc_req.context["parent_condition"]["text"] == "root"
+    assert disc_req.context["ancestors"] == []
+
+    val_req = next(
+        r
+        for r in requests
+        if r.kind == "RETRIEVE" and r.context["condition"]["text"] == "root.child"
+    )
+    assert val_req.context["ancestors"][0]["text"] == "root"
+
+
+def test_discovery_depth_limit_respected():
+    async def agent(req: NLRequest) -> NLResponse:
+        if req.kind == "DISCOVER":
+            parent_text = req.context["parent_condition"]["text"]
+            if parent_text == "root":
+                return NLResponse(final="", children=[{"text": "child1"}])
+            if parent_text == "child1":
+                return NLResponse(final="", children=[{"text": "grandchild"}])
+            return NLResponse(final="", children=[])
+        return NLResponse(final="PASS: ok")
+
+    finding = Finding(claim="c", origin_file="o")
+    finding.root_conditions.append(Condition(text="root"))
+
+    orch = Orchestrator(agent, discover_depth=1)
+    asyncio.run(orch.run([finding]))
+
+    root = finding.root_conditions[0]
+    assert len(root.children) == 1
+    assert root.children[0].text == "child1"
+    assert root.children[0].children == []


### PR DESCRIPTION
## Summary
- allow conditions to track children and identity for parent linking
- expand orchestrator with discovery and validation phases passing ancestor context
- add CLI flag for discovery depth and comprehensive tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897f3a7ae648324920427e24a45a647