### PR TITLE
Implement on-demand discovery for UNKNOWN conditions

### DIFF
--- a/auditor/cli/main.py
+++ b/auditor/cli/main.py
@@ -12,10 +12,23 @@ from auditor.report.render import render_report
 def main() -> None:
     parser = argparse.ArgumentParser(description="Run auditor prototype")
     parser.add_argument("--repo", default=".", help="Path to repository root")
-    parser.add_argument("--discover-depth", type=int, default=0, help="Depth for discovery phase")
+    parser.add_argument("--max-depth", type=int, default=0, help="Maximum discovery depth")
+    parser.add_argument(
+        "--max-fanout", type=int, default=10, help="Maximum number of children per node"
+    )
+    parser.add_argument(
+        "--no-discover-on-unknown",
+        action="store_true",
+        help="Disable DISCOVER calls when status is UNKNOWN",
+    )
     args = parser.parse_args()
 
-    orch = Orchestrator(shell_agent.run, discover_depth=args.discover_depth)
+    orch = Orchestrator(
+        shell_agent.run,
+        max_depth=args.max_depth,
+        max_fanout=args.max_fanout,
+        discover_on_unknown=not args.no_discover_on_unknown,
+    )
 
     finding = Finding(claim="placeholder", origin_file="")
     finding.root_conditions.append(Condition(text="stub"))

--- a/auditor/core/orchestrator.py
+++ b/auditor/core/orchestrator.py
@@ -3,14 +3,16 @@
 import time
 import dataclasses
 from dataclasses import dataclass
-from typing import Awaitable, Callable, List, Tuple
+from typing import Awaitable, Callable, List
 
 from auditor.agent.interface import NLRequest, NLResponse
 from auditor.core.models import AuditReport, Condition, Finding, Status
 
 
 def _status_from(text: str) -> Status:
-    t = text.lower()
+    """Map natural language response text to a ``Status``."""
+
+    t = (text or "").strip().lower()
     if "satisf" in t or "pass" in t:
         return Status.SATISFIED
     if "violate" in t or "fail" in t:
@@ -22,78 +24,68 @@ def _to_dict(obj):
     return dataclasses.asdict(obj)
 
 
-def _conditions_without_children(f: Finding) -> List[Tuple[Condition, List[Condition]]]:
-    result: List[Tuple[Condition, List[Condition]]] = []
-
-    def visit(cond: Condition, ancestors: List[Condition]) -> None:
-        if not cond.children:
-            result.append((cond, ancestors))
-        else:
-            for child in cond.children:
-                visit(child, ancestors + [cond])
-
-    for root in f.root_conditions:
-        visit(root, [])
-    return result
-
-
-def _walk_all_conditions(f: Finding) -> List[Tuple[Condition, List[Condition]]]:
-    result: List[Tuple[Condition, List[Condition]]] = []
-
-    def visit(cond: Condition, ancestors: List[Condition]) -> None:
-        result.append((cond, ancestors))
-        for child in cond.children:
-            visit(child, ancestors + [cond])
-
-    for root in f.root_conditions:
-        visit(root, [])
-    return result
-
-
 @dataclass
 class Orchestrator:
+    """Coordinate retrieval and discovery of conditions."""
+
     agent_run: Callable[[NLRequest], Awaitable[NLResponse]]
-    discover_depth: int = 0
+    max_depth: int = 0
+    max_fanout: int = 10
+    discover_on_unknown: bool = True
 
     async def run(self, findings: List[Finding]) -> AuditReport:
         started = time.time()
-        if self.discover_depth > 0:
-            await self._discover(findings, self.discover_depth)
-        await self._validate(findings)
+        for f in findings:
+            for root in f.root_conditions:
+                await self._eval_node(f, root, [], 0)
         finished = time.time()
         return AuditReport(findings=findings, started_at=started, finished_at=finished)
 
-    async def _discover(self, findings: List[Finding], depth: int) -> None:
-        for _ in range(depth):
-            for f in findings:
-                for cond, ancestors in _conditions_without_children(f):
-                    req = NLRequest(
-                        kind="DISCOVER",
-                        objective=f"Expand: {cond.text}",
-                        context={
-                            "finding": _to_dict(f),
-                            "parent_condition": _to_dict(cond),
-                            "ancestors": [_to_dict(a) for a in ancestors],
-                        },
-                    )
-                    res: NLResponse = await self.agent_run(req)
-                    for child_spec in res.children:
-                        child = Condition(text=child_spec.get("text", ""), parent_id=cond.id)
-                        cond.children.append(child)
+    async def _eval_node(
+        self, finding: Finding, cond: Condition, ancestors: List[Condition], depth: int
+    ) -> None:
+        req = NLRequest(
+            kind="RETRIEVE",
+            objective=f"Validate: {cond.text}",
+            context={
+                "finding": _to_dict(finding),
+                "condition": _to_dict(cond),
+                "ancestors": [_to_dict(a) for a in ancestors],
+            },
+        )
+        try:
+            res = await self.agent_run(req)
+        except Exception:  # pragma: no cover - agent failures
+            res = NLResponse(final="")
 
-    async def _validate(self, findings: List[Finding]) -> None:
-        for f in findings:
-            for cond, ancestors in _walk_all_conditions(f):
-                req = NLRequest(
-                    kind="RETRIEVE",
-                    objective=f"Validate: {cond.text}",
-                    context={
-                        "finding": _to_dict(f),
-                        "condition": _to_dict(cond),
-                        "ancestors": [_to_dict(a) for a in ancestors],
-                    },
-                )
-                res: NLResponse = await self.agent_run(req)
-                status = _status_from(res.final)
-                cond.plan_params["status"] = status.value
-                cond.plan_params["final"] = res.final
+        status = _status_from(res.final)
+        cond.plan_params.update(status=status.value, final=res.final)
+
+        if status != Status.UNKNOWN or depth >= self.max_depth:
+            return
+
+        kids = res.children
+        if not kids and self.discover_on_unknown:
+            dreq = NLRequest(
+                kind="DISCOVER",
+                objective=f"Expand: {cond.text}",
+                context={
+                    "finding": _to_dict(finding),
+                    "parent_condition": _to_dict(cond),
+                    "ancestors": [_to_dict(a) for a in ancestors],
+                },
+            )
+            try:
+                dres = await self.agent_run(dreq)
+                kids = dres.children
+            except Exception:  # pragma: no cover - agent failures
+                kids = []
+
+        for spec in (kids or [])[: self.max_fanout]:
+            child = Condition(text=spec.get("text", ""), parent_id=cond.id)
+            cond.children.append(child)
+            await self._eval_node(finding, child, ancestors + [cond], depth + 1)
+
+
+__all__ = ["Orchestrator", "_status_from"]
+

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -5,59 +5,108 @@ from auditor.core.models import Condition, Finding
 from auditor.core.orchestrator import Orchestrator
 
 
-def test_discovery_creates_children_and_parent_context():
+def test_depth_zero_no_children():
+    requests = []
+
+    async def agent(req: NLRequest) -> NLResponse:
+        requests.append(req)
+        return NLResponse(final="maybe")
+
+    finding = Finding(claim="c", origin_file="o")
+    finding.root_conditions.append(Condition(text="root"))
+
+    orch = Orchestrator(agent, max_depth=0)
+    asyncio.run(orch.run([finding]))
+
+    root = finding.root_conditions[0]
+    assert root.children == []
+    assert all(r.kind == "RETRIEVE" for r in requests)
+
+
+def test_unknown_triggers_discover_until_depth():
     requests = []
 
     async def agent(req: NLRequest) -> NLResponse:
         requests.append(req)
         if req.kind == "DISCOVER":
-            parent_text = req.context["parent_condition"]["text"]
-            return NLResponse(final="", children=[{"text": f"{parent_text}.child"}])
-        return NLResponse(final="PASS: ok")
+            parent = req.context["parent_condition"]["text"]
+            if parent == "root":
+                return NLResponse(final="", children=[{"text": "child"}])
+            if parent == "child":
+                return NLResponse(final="", children=[{"text": "grand"}])
+            return NLResponse(final="", children=[])
+        text = req.context["condition"]["text"]
+        if text == "grand":
+            return NLResponse(final="PASS: done")
+        return NLResponse(final="maybe")
 
-    orch = Orchestrator(agent, discover_depth=1)
-    finding = Finding(claim="claim", origin_file="orig")
+    finding = Finding(claim="c", origin_file="o")
     finding.root_conditions.append(Condition(text="root"))
 
+    orch = Orchestrator(agent, max_depth=2)
     asyncio.run(orch.run([finding]))
 
     root = finding.root_conditions[0]
-    assert root.children and root.children[0].text == "root.child"
-
+    assert [c.text for c in root.children] == ["child"]
     child = root.children[0]
-    assert child.plan_params["status"] == "SATISFIED"
-    assert "PASS" in child.plan_params["final"]
-
-    disc_req = next(r for r in requests if r.kind == "DISCOVER")
-    assert disc_req.context["parent_condition"]["text"] == "root"
-    assert disc_req.context["ancestors"] == []
-
-    val_req = next(
-        r
-        for r in requests
-        if r.kind == "RETRIEVE" and r.context["condition"]["text"] == "root.child"
-    )
-    assert val_req.context["ancestors"][0]["text"] == "root"
+    assert [c.text for c in child.children] == ["grand"]
+    assert child.children[0].children == []
+    assert sum(1 for r in requests if r.kind == "DISCOVER") == 2
 
 
-def test_discovery_depth_limit_respected():
+def test_fanout_cap_enforced():
     async def agent(req: NLRequest) -> NLResponse:
         if req.kind == "DISCOVER":
-            parent_text = req.context["parent_condition"]["text"]
-            if parent_text == "root":
-                return NLResponse(final="", children=[{"text": "child1"}])
-            if parent_text == "child1":
-                return NLResponse(final="", children=[{"text": "grandchild"}])
-            return NLResponse(final="", children=[])
+            return NLResponse(
+                final="",
+                children=[{ "text": f"child{i}" } for i in range(5)],
+            )
+        return NLResponse(final="maybe")
+
+    finding = Finding(claim="c", origin_file="o")
+    finding.root_conditions.append(Condition(text="root"))
+
+    orch = Orchestrator(agent, max_depth=1, max_fanout=2)
+    asyncio.run(orch.run([finding]))
+
+    root = finding.root_conditions[0]
+    assert len(root.children) == 2
+
+
+def test_retrieve_children_respected_without_discover():
+    requests = []
+
+    async def agent(req: NLRequest) -> NLResponse:
+        requests.append(req)
+        if req.kind == "RETRIEVE" and req.context["condition"]["text"] == "root":
+            return NLResponse(final="maybe", children=[{"text": "child"}])
         return NLResponse(final="PASS: ok")
 
     finding = Finding(claim="c", origin_file="o")
     finding.root_conditions.append(Condition(text="root"))
 
-    orch = Orchestrator(agent, discover_depth=1)
+    orch = Orchestrator(agent, max_depth=1)
     asyncio.run(orch.run([finding]))
 
     root = finding.root_conditions[0]
-    assert len(root.children) == 1
-    assert root.children[0].text == "child1"
-    assert root.children[0].children == []
+    assert [c.text for c in root.children] == ["child"]
+    assert sum(1 for r in requests if r.kind == "DISCOVER") == 0
+
+
+def test_no_discover_when_disabled():
+    requests = []
+
+    async def agent(req: NLRequest) -> NLResponse:
+        requests.append(req)
+        return NLResponse(final="maybe")
+
+    finding = Finding(claim="c", origin_file="o")
+    finding.root_conditions.append(Condition(text="root"))
+
+    orch = Orchestrator(agent, max_depth=1, discover_on_unknown=False)
+    asyncio.run(orch.run([finding]))
+
+    root = finding.root_conditions[0]
+    assert root.children == []
+    assert sum(1 for r in requests if r.kind == "DISCOVER") == 0
+


### PR DESCRIPTION
## Summary
- add depth- and fanout-controlled discovery that only expands UNKNOWN conditions
- expose new `--max-depth`, `--max-fanout`, and discovery toggle in CLI
- test recursive discovery, fanout limit, retrieval-provided children, and disabled discovery

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6897f62baa388324bea1ad9a5ab37534