### PR TITLE
Add random branching demo mode with streaming updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # recon
+
+Prototype auditor.
+
+## Random demo mode
+
+Run with pseudo-random branching and live streaming:
+
+```
+python3 main.py --random --findings 3 --max-depth 3 --max-fanout 3 --seed 42
+```

--- a/auditor/agent/random_agent.py
+++ b/auditor/agent/random_agent.py
@@ -1,0 +1,37 @@
+"""Pseudo-random agent for demo mode."""
+
+from __future__ import annotations
+
+import random
+from typing import List
+
+from .interface import NLRequest, NLResponse
+
+
+class RandomAgent:
+    """Agent that generates stochastic responses for testing."""
+
+    def __init__(self, seed: int | None = None, max_children: int = 0) -> None:
+        self._rng = random.Random(seed)
+        self._max_children = max_children
+
+    async def run(self, request: NLRequest) -> NLResponse:
+        if request.kind == "RETRIEVE":
+            outcome = self._rng.choices(
+                ["PASS: looks good", "FAIL: needs work", "maybe"],
+                weights=[1, 1, 3],
+            )[0]
+            return NLResponse(final=outcome)
+
+        if request.kind == "DISCOVER":
+            parent = request.context.get("parent_condition", {}).get("text", "")
+            count = self._rng.randint(0, self._max_children)
+            kids: List[dict] = [
+                {"text": f"{parent} \u203a sub-{i}"} for i in range(count)
+            ]
+            return NLResponse(final="", children=kids)
+
+        return NLResponse(final="maybe")
+
+
+__all__ = ["RandomAgent"]

--- a/auditor/cli/main.py
+++ b/auditor/cli/main.py
@@ -4,6 +4,7 @@ import argparse
 import asyncio
 
 from auditor.agent import shell_agent
+from auditor.agent.random_agent import RandomAgent
 from auditor.core.models import Condition, Finding
 from auditor.core.orchestrator import Orchestrator
 from auditor.report.render import render_report
@@ -21,19 +22,53 @@ def main() -> None:
         action="store_true",
         help="Disable DISCOVER calls when status is UNKNOWN",
     )
+    parser.add_argument("--random", action="store_true", help="Use random agent")
+    parser.add_argument("--seed", type=int, help="Seed for random agent")
+    parser.add_argument("--findings", type=int, default=1, help="Number of initial findings")
+    parser.add_argument("--no-stream", action="store_true", help="Disable live event stream")
     args = parser.parse_args()
 
+    def printer(evt: str, data: dict) -> None:
+        depth = data.get("depth", 0)
+        indent = "  " * depth
+        if evt == "node:start":
+            print(f"{indent}- {data.get('condition', '')}", flush=True)
+        elif evt == "node:result":
+            status = data.get("status", "")
+            final = data.get("final", "")
+            print(f"{indent}  -> {status}: {final}", flush=True)
+        elif evt == "discover:start":
+            print(f"{indent}  ? discover", flush=True)
+        elif evt == "discover:result":
+            kids = data.get("children", [])
+            print(f"{indent}  discovered {len(kids)}", flush=True)
+        elif evt == "child:add":
+            print(f"{indent}  + {data.get('condition', '')}", flush=True)
+
+    if args.random:
+        agent = RandomAgent(seed=args.seed, max_children=args.max_fanout).run
+        findings = []
+        for i in range(args.findings):
+            f = Finding(claim=f"random-claim-{i+1}", origin_file="random")
+            f.root_conditions.append(Condition(text=f"root-{i+1}"))
+            findings.append(f)
+        on_event = None if args.no_stream else printer
+    else:
+        agent = shell_agent.run
+        f = Finding(claim="placeholder", origin_file="")
+        f.root_conditions.append(Condition(text="stub"))
+        findings = [f]
+        on_event = None
+
     orch = Orchestrator(
-        shell_agent.run,
+        agent,
         max_depth=args.max_depth,
         max_fanout=args.max_fanout,
         discover_on_unknown=not args.no_discover_on_unknown,
+        on_event=on_event,
     )
 
-    finding = Finding(claim="placeholder", origin_file="")
-    finding.root_conditions.append(Condition(text="stub"))
-
-    report = asyncio.run(orch.run([finding]))
+    report = asyncio.run(orch.run(findings))
     print(render_report(report))
 
 

--- a/tests/test_cli_random_mode.py
+++ b/tests/test_cli_random_mode.py
@@ -1,0 +1,32 @@
+import pathlib
+import subprocess
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+def run_cli(args):
+    cmd = [sys.executable, "main.py"] + args
+    return subprocess.check_output(cmd, cwd=ROOT, text=True)
+
+
+def test_cli_default_runs():
+    out = run_cli(["--max-depth", "0", "--no-discover-on-unknown"])
+    assert "# Audit Report" in out
+
+
+def test_cli_random_seed_repeatable():
+    args = [
+        "--random",
+        "--findings",
+        "1",
+        "--max-depth",
+        "0",
+        "--no-stream",
+        "--seed",
+        "123",
+    ]
+    out1 = run_cli(args)
+    out2 = run_cli(args)
+    assert out1 == out2
+    assert out1.startswith("# Audit Report")

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,0 +1,42 @@
+import asyncio
+
+from auditor.agent.interface import NLRequest, NLResponse
+from auditor.core.models import Condition, Finding
+from auditor.core.orchestrator import Orchestrator
+
+
+def test_orchestrator_emits_events_with_depth():
+    events = []
+
+    async def agent(req: NLRequest) -> NLResponse:
+        if req.kind == "DISCOVER":
+            return NLResponse(final="", children=[{"text": "child"}])
+        text = req.context["condition"]["text"]
+        if text == "child":
+            return NLResponse(final="PASS: ok")
+        return NLResponse(final="maybe")
+
+    def on_event(evt: str, data: dict) -> None:
+        events.append((evt, data))
+
+    finding = Finding(claim="c", origin_file="o")
+    finding.root_conditions.append(Condition(text="root"))
+
+    orch = Orchestrator(agent, max_depth=1, on_event=on_event)
+    asyncio.run(orch.run([finding]))
+
+    names = [e[0] for e in events]
+    assert names == [
+        "node:start",
+        "node:result",
+        "discover:start",
+        "discover:result",
+        "child:add",
+        "node:start",
+        "node:result",
+    ]
+    # Depth and condition propagated
+    assert events[0][1]["depth"] == 0
+    assert events[0][1]["condition"] == "root"
+    assert events[4][1]["depth"] == 1
+    assert events[4][1]["condition"] == "child"

--- a/tests/test_random_agent.py
+++ b/tests/test_random_agent.py
@@ -1,0 +1,28 @@
+import asyncio
+
+from auditor.agent.interface import NLRequest
+from auditor.agent.random_agent import RandomAgent
+
+
+def test_random_agent_seed_and_bounds():
+    agent_a = RandomAgent(seed=42, max_children=3)
+    agent_b = RandomAgent(seed=42, max_children=3)
+
+    async def run(agent):
+        r1 = await agent.run(NLRequest(kind="RETRIEVE", objective="o"))
+        r2 = await agent.run(
+            NLRequest(
+                kind="DISCOVER",
+                objective="o",
+                context={"parent_condition": {"text": "root"}},
+            )
+        )
+        return r1, r2
+
+    a1, a2 = asyncio.run(run(agent_a))
+    b1, b2 = asyncio.run(run(agent_b))
+
+    assert a1.final in {"PASS: looks good", "FAIL: needs work", "maybe"}
+    assert a1.final == b1.final
+    assert a2.children == b2.children
+    assert len(a2.children) <= 3


### PR DESCRIPTION
## Summary
- implement pseudo-random agent and CLI flag to trigger demo mode with optional seed
- add event callbacks to orchestrator and live printer for streaming progress
- document new random demo mode in README

## Testing
- `pytest -q`
- `python main.py --random --findings 1 --max-depth 2 --max-fanout 3 --seed 1`


------
https://chatgpt.com/codex/tasks/task_e_6897f8f3d344832488fe541d52896d11