### PR TITLE
feat: add JSON reporting and tagged CLI stream

### DIFF
--- a/auditor/cli/main.py
+++ b/auditor/cli/main.py
@@ -2,12 +2,14 @@
 
 import argparse
 import asyncio
+import os
+import sys
 
 from auditor.agent import shell_agent
 from auditor.agent.random_agent import RandomAgent
 from auditor.core.models import Condition, Finding
 from auditor.core.orchestrator import Orchestrator
-from auditor.report.render import render_report
+from auditor.report.render import _tag, render_report_json, render_report_text
 
 
 def main() -> None:
@@ -26,24 +28,55 @@ def main() -> None:
     parser.add_argument("--seed", type=int, help="Seed for random agent")
     parser.add_argument("--findings", type=int, default=1, help="Number of initial findings")
     parser.add_argument("--no-stream", action="store_true", help="Disable live event stream")
+    parser.add_argument(
+        "--format",
+        choices=["text", "json", "json-pretty"],
+        default="text",
+        help="Output format for final report",
+    )
+    parser.add_argument(
+        "--with-tags",
+        action="store_true",
+        help="Include ids in text report",
+    )
     args = parser.parse_args()
+
+    use_color = sys.stdout.isatty() and "NO_COLOR" not in os.environ
+    ICONS = {"SATISFIED": "✔", "VIOLATED": "✖", "UNKNOWN": "?"}
+    COLORS = {
+        "SATISFIED": "\x1b[32m",
+        "VIOLATED": "\x1b[31m",
+        "UNKNOWN": "\x1b[33m",
+        "RESET": "\x1b[0m",
+    }
 
     def printer(evt: str, data: dict) -> None:
         depth = data.get("depth", 0)
-        indent = "  " * depth
+        indent = "  " * (depth + 1)
         if evt == "node:start":
-            print(f"{indent}- {data.get('condition', '')}", flush=True)
+            if depth == 0:
+                print(f"{_tag('FINDING', data.get('finding_id'))} {data.get('condition', '')}", flush=True)
         elif evt == "node:result":
-            status = data.get("status", "")
+            status = data.get("status", "UNKNOWN")
             final = data.get("final", "")
-            print(f"{indent}  -> {status}: {final}", flush=True)
-        elif evt == "discover:start":
-            print(f"{indent}  ? discover", flush=True)
+            icon = ICONS.get(status, "")
+            status_text = status
+            if use_color and status in COLORS:
+                color = COLORS[status]
+                icon = f"{color}{icon}{COLORS['RESET']}"
+                status_text = f"{color}{status}{COLORS['RESET']}"
+            print(
+                f"{indent}{_tag('COND', data.get('id'))} -> {icon} {status_text}: {final}",
+                flush=True,
+            )
         elif evt == "discover:result":
             kids = data.get("children", [])
-            print(f"{indent}  discovered {len(kids)}", flush=True)
+            print(f"{indent}[DISCOVER] discovered={len(kids)}", flush=True)
         elif evt == "child:add":
-            print(f"{indent}  + {data.get('condition', '')}", flush=True)
+            print(
+                f"{indent}{_tag('CHILD', data.get('id'))} {data.get('condition', '')}",
+                flush=True,
+            )
 
     if args.random:
         agent = RandomAgent(seed=args.seed, max_children=args.max_fanout).run
@@ -69,7 +102,12 @@ def main() -> None:
     )
 
     report = asyncio.run(orch.run(findings))
-    print(render_report(report))
+    if args.format == "json":
+        print(render_report_json(report))
+    elif args.format == "json-pretty":
+        print(render_report_json(report, pretty=True))
+    else:
+        print(render_report_text(report, with_tags=args.with_tags))
 
 
 if __name__ == "__main__":  # pragma: no cover - entry point

--- a/auditor/core/models.py
+++ b/auditor/core/models.py
@@ -32,6 +32,7 @@ class Finding:
     claim: str
     origin_file: str
     root_conditions: List[Condition] = field(default_factory=list)
+    id: str = field(default_factory=lambda: uuid.uuid4().hex)
 
 
 @dataclass

--- a/auditor/core/orchestrator.py
+++ b/auditor/core/orchestrator.py
@@ -49,7 +49,15 @@ class Orchestrator:
     async def _eval_node(
         self, finding: Finding, cond: Condition, ancestors: List[Condition], depth: int
     ) -> None:
-        self._emit("node:start", {"condition": cond.text, "depth": depth})
+        self._emit(
+            "node:start",
+            {
+                "condition": cond.text,
+                "id": cond.id,
+                "depth": depth,
+                "finding_id": finding.id,
+            },
+        )
         req = NLRequest(
             kind="RETRIEVE",
             objective=f"Validate: {cond.text}",
@@ -66,7 +74,17 @@ class Orchestrator:
 
         status = _status_from(res.final)
         cond.plan_params.update(status=status.value, final=res.final)
-        self._emit("node:result", {"condition": cond.text, "depth": depth, "status": status.value, "final": res.final})
+        self._emit(
+            "node:result",
+            {
+                "condition": cond.text,
+                "id": cond.id,
+                "depth": depth,
+                "status": status.value,
+                "final": res.final,
+                "finding_id": finding.id,
+            },
+        )
 
         if status != Status.UNKNOWN or depth >= self.max_depth:
             return
@@ -83,17 +101,31 @@ class Orchestrator:
                 },
             )
             try:
-                self._emit("discover:start", {"condition": cond.text, "depth": depth})
+                self._emit(
+                    "discover:start",
+                    {"condition": cond.text, "id": cond.id, "depth": depth},
+                )
                 dres = await self.agent_run(dreq)
                 kids = dres.children
             except Exception:  # pragma: no cover - agent failures
                 kids = []
-            self._emit("discover:result", {"condition": cond.text, "depth": depth, "children": kids})
+            self._emit(
+                "discover:result",
+                {"condition": cond.text, "id": cond.id, "depth": depth, "children": kids},
+            )
 
         for spec in (kids or [])[: self.max_fanout]:
             child = Condition(text=spec.get("text", ""), parent_id=cond.id)
             cond.children.append(child)
-            self._emit("child:add", {"condition": child.text, "depth": depth + 1})
+            self._emit(
+                "child:add",
+                {
+                    "condition": child.text,
+                    "id": child.id,
+                    "parent_id": cond.id,
+                    "depth": depth + 1,
+                },
+            )
             await self._eval_node(finding, child, ancestors + [cond], depth + 1)
 
 

--- a/auditor/report/render.py
+++ b/auditor/report/render.py
@@ -1,19 +1,41 @@
 """Helpers to render audit reports."""
 
+import dataclasses
+import json
 from typing import List
 
 from auditor.core.models import AuditReport
 
 
-def render_report(report: AuditReport) -> str:
+def _tag(prefix: str, identifier: str) -> str:
+    """Return a bracketed tag for ``identifier``."""
+    return f"[{prefix}:{identifier}]"
+
+
+def render_report_text(report: AuditReport, with_tags: bool = False) -> str:
+    """Render a human readable audit report."""
     lines: List[str] = ["# Audit Report"]
     for idx, finding in enumerate(report.findings, 1):
-        lines.append(f"## Finding {idx}: {finding.claim}")
+        tag = f"{_tag('FINDING', finding.id)} " if with_tags else ""
+        lines.append(f"## {tag}Finding {idx}: {finding.claim}")
         lines.append(f"Origin: {finding.origin_file}")
         for cond in finding.root_conditions:
             status = cond.plan_params.get("status", "UNKNOWN")
             final = cond.plan_params.get("final", "")
-            lines.append(f"- [{status}] {cond.text}")
+            ctag = f"{_tag('COND', cond.id)} " if with_tags else ""
+            lines.append(f"- {ctag}[{status}] {cond.text}")
             if final:
                 lines.append(f"    → {final}")
     return "\n".join(lines) + "\n"
+
+
+def render_report_json(report: AuditReport, pretty: bool = False) -> str:
+    """Render ``AuditReport`` as JSON."""
+    data = dataclasses.asdict(report)
+    data["duration"] = report.finished_at - report.started_at
+    if pretty:
+        return json.dumps(data, indent=2)
+    return json.dumps(data)
+
+
+__all__ = ["render_report_text", "render_report_json", "_tag"]

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -35,8 +35,12 @@ def test_orchestrator_emits_events_with_depth():
         "node:start",
         "node:result",
     ]
-    # Depth and condition propagated
-    assert events[0][1]["depth"] == 0
-    assert events[0][1]["condition"] == "root"
-    assert events[4][1]["depth"] == 1
-    assert events[4][1]["condition"] == "child"
+    # Depth, condition, and ids propagated
+    first = events[0][1]
+    child_evt = events[4][1]
+    assert first["depth"] == 0
+    assert first["condition"] == "root"
+    assert "id" in first and "finding_id" in first
+    assert child_evt["depth"] == 1
+    assert child_evt["condition"] == "child"
+    assert "id" in child_evt and child_evt["parent_id"]

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -2,8 +2,10 @@ import asyncio
 
 from auditor.agent.interface import NLRequest, NLResponse
 from auditor.core.models import Condition, Finding
+import json
+
 from auditor.core.orchestrator import Orchestrator
-from auditor.report.render import render_report
+from auditor.report.render import render_report_text, render_report_json
 
 
 async def dummy_agent(req: NLRequest) -> NLResponse:
@@ -18,6 +20,8 @@ def test_orchestrator_report_includes_status_and_final():
     cond = report.findings[0].root_conditions[0]
     assert cond.plan_params["status"] == "SATISFIED"
     assert "PASS" in cond.plan_params["final"]
-    text = render_report(report)
+    text = render_report_text(report)
     assert "[SATISFIED]" in text
     assert "PASS:" in text
+    data = json.loads(render_report_json(report))
+    assert data["findings"][0]["id"] == finding.id


### PR DESCRIPTION
## Summary
- colorize and tag streamed CLI output with condition IDs
- support `--format` flag to output audit reports as text or JSON
- include finding IDs in models and event payloads for correlation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897fc12bfec8324b7be51e5adede5c6