### PR TITLE
refactor: simplify agent outputs

### DIFF
--- a/auditor/agent/interface.py
+++ b/auditor/agent/interface.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel, Field
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict
 
 
 class NLRequest(BaseModel):
@@ -9,12 +9,6 @@ class NLRequest(BaseModel):
     limits: Dict[str, Any] = {}
 
 
-class Evidence(BaseModel):
-    path: str
-    line: int
-    snippet: str
-    note: Optional[str] = None
-
-
 class NLResponse(BaseModel):
-    evidence: List[Evidence] = Field(default_factory=list)
+    output: str = ""
+    meta: Dict[str, Any] = Field(default_factory=dict)

--- a/auditor/agent/random_agent.py
+++ b/auditor/agent/random_agent.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import random
 
-from .interface import Evidence, NLRequest, NLResponse
+from .interface import NLRequest, NLResponse
 
 
 class RandomAgent:
@@ -15,12 +15,11 @@ class RandomAgent:
         self._max_children = max_children
 
     async def run(self, request: NLRequest) -> NLResponse:
-        snippet = self._rng.choices(
+        output = self._rng.choices(
             ["PASS: looks good", "FAIL: needs work", "maybe"],
             weights=[1, 1, 3],
         )[0]
-        ev = Evidence(path="random.txt", line=1, snippet=snippet)
-        return NLResponse(evidence=[ev])
+        return NLResponse(output=output)
 
 
 __all__ = ["RandomAgent"]

--- a/auditor/agent/shell_agent.py
+++ b/auditor/agent/shell_agent.py
@@ -2,7 +2,7 @@
 
 import asyncio
 
-from .interface import Evidence, NLRequest, NLResponse
+from .interface import NLRequest, NLResponse
 
 
 async def run(request: NLRequest) -> NLResponse:
@@ -13,11 +13,11 @@ async def run(request: NLRequest) -> NLResponse:
     )
     out, _ = await proc.communicate()
     lines = out.decode("utf-8", "ignore").splitlines()
-    evidence = []
+    matches = []
     for line in lines:
         try:
             path, lineno, snippet = line.split(":", 2)
-            evidence.append(Evidence(path=path, line=int(lineno), snippet=snippet.strip()))
+            matches.append(f"{path}:{lineno}:{snippet.strip()}")
         except ValueError:
             continue
-    return NLResponse(evidence=evidence)
+    return NLResponse(output="\n".join(matches))

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,6 +1,6 @@
 import asyncio
 
-from auditor.agent.interface import Evidence, NLRequest, NLResponse
+from auditor.agent.interface import NLRequest, NLResponse
 from auditor.core.models import Condition, Finding
 from auditor.core.orchestrator import Orchestrator
 
@@ -11,8 +11,7 @@ def test_orchestrator_emits_events_with_depth():
     async def agent(req: NLRequest) -> NLResponse:
         text = req.context["condition"]["text"]
         if text == "child":
-            ev = Evidence(path="p", line=1, snippet="PASS: ok")
-            return NLResponse(evidence=[ev])
+            return NLResponse(output="PASS: ok")
         return NLResponse()
 
     def on_event(evt: str, data: dict) -> None:
@@ -21,7 +20,7 @@ def test_orchestrator_emits_events_with_depth():
     finding = Finding(claim="c", origin_file="o")
     finding.root_conditions.append(Condition(text="root"))
 
-    discover_fn = lambda c: ["child"] if c.text == "root" else []
+    discover_fn = lambda c, o: ["child"] if c.text == "root" else []
     orch = Orchestrator(agent, max_depth=1, on_event=on_event, discover_fn=discover_fn)
     asyncio.run(orch.run([finding]))
 

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1,6 +1,6 @@
 import asyncio
 
-from auditor.agent.interface import Evidence, NLRequest, NLResponse
+from auditor.agent.interface import NLRequest, NLResponse
 from auditor.core.models import Condition, Finding
 import json
 
@@ -9,7 +9,7 @@ from auditor.report.render import render_report_text, render_report_json
 
 
 async def dummy_agent(req: NLRequest) -> NLResponse:
-    return NLResponse(evidence=[Evidence(path="p.txt", line=1, snippet="PASS: looks good")])
+    return NLResponse(output="PASS: looks good")
 
 
 def test_orchestrator_report_includes_status_and_final():

--- a/tests/test_random_agent.py
+++ b/tests/test_random_agent.py
@@ -17,6 +17,6 @@ def test_random_agent_seed_and_bounds():
     b1, b2 = asyncio.run(run(agent_b))
 
     choices = {"PASS: looks good", "FAIL: needs work", "maybe"}
-    assert a1.evidence[0].snippet in choices
-    assert a1.evidence[0].snippet == b1.evidence[0].snippet
-    assert a2.evidence[0].snippet == b2.evidence[0].snippet
+    assert a1.output in choices
+    assert a1.output == b1.output
+    assert a2.output == b2.output

--- a/tests/test_shell_agent.py
+++ b/tests/test_shell_agent.py
@@ -4,15 +4,12 @@ from auditor.agent.interface import NLRequest
 from auditor.agent import shell_agent
 
 
-def test_shell_agent_returns_evidence(tmp_path, monkeypatch):
+def test_shell_agent_returns_output(tmp_path, monkeypatch):
     (tmp_path / "a.txt").write_text("no todos here")
     monkeypatch.chdir(tmp_path)
     req = NLRequest(objective="find todos")
     res = asyncio.run(shell_agent.run(req))
-    assert res.evidence == []
+    assert res.output == ""
     (tmp_path / "b.txt").write_text("TODO one")
     res = asyncio.run(shell_agent.run(req))
-    assert len(res.evidence) == 1
-    ev = res.evidence[0]
-    assert ev.path.endswith("b.txt")
-    assert ev.line == 1
+    assert "b.txt:1:TODO one" in res.output

--- a/tests/test_status_mapping.py
+++ b/tests/test_status_mapping.py
@@ -1,9 +1,8 @@
-from auditor.agent.interface import Evidence
-from auditor.core.orchestrator import _status_from_evidence
+from auditor.core.orchestrator import _status_from_output
 from auditor.core.models import Status
 
 
-def test_status_from_evidence():
-    assert _status_from_evidence([Evidence(path="", line=1, snippet="PASS: ok")]) is Status.SATISFIED
-    assert _status_from_evidence([Evidence(path="", line=1, snippet="FAIL: nope")]) is Status.VIOLATED
-    assert _status_from_evidence([]) is Status.UNKNOWN
+def test_status_from_output():
+    assert _status_from_output("PASS: ok") is Status.SATISFIED
+    assert _status_from_output("FAIL: nope") is Status.VIOLATED
+    assert _status_from_output("") is Status.UNKNOWN


### PR DESCRIPTION
## Summary
- refactor agents to return raw output strings instead of Evidence objects
- rework orchestrator to classify status from agent output and store retrieval metadata
- update agent implementations and tests for the new NLResponse contract

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689809bd55708324ba49d32c5bff0f9a