### PR TITLE
feat: orchestrate audits with LLM-driven agent

### DIFF
--- a/auditor/agent/llm_agent.py
+++ b/auditor/agent/llm_agent.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from auditor.agent.interface import NLRequest, NLResponse
+from auditor.agent.openai import openai_generate_response
+import json
+import re
+
+SYSTEM_PROMPT = """
+You are the Audit Orchestrator.
+Responsibilities:
+1) JUDGMENT: Decide if the condition is SATISFIED, VIOLATED, or UNKNOWN.
+2) TASKS: Propose concrete retrieval tasks ("next_tasks") that would best reduce uncertainty.
+3) CHILDREN: Propose optional child conditions that decompose the condition if UNKNOWN or if finer validation helps.
+Output STRICT JSON exactly matching the provided schema. No extra text.
+Rules:
+- status ∈ {SATISFIED, VIOLATED, UNKNOWN}
+- Keep final concise, evidence-focused.
+- Max children = {max_fanout}; omit if not needed.
+- Prefer 0 children when status ≠ UNKNOWN.
+"""
+
+USER_TEMPLATE = """
+Finding:
+{finding}
+
+Condition:
+{text}
+
+Ancestors (shallow summaries ok):
+{ancestors}
+
+Limits:
+max_depth_remaining={max_depth_remaining}, max_fanout={max_fanout}
+
+Schema:
+{schema}
+"""
+
+SCHEMA_JSON = {
+    "status": "SATISFIED|VIOLATED|UNKNOWN",
+    "final": "string",
+    "children": ["string"],
+    "next_tasks": [{"kind": "RETRIEVE", "objective": "string"}],
+    "notes": "string",
+}
+
+JSON_RE = re.compile(r"\{.*\}", re.S)  # naive top-level JSON capture
+
+
+async def run(req: NLRequest) -> NLResponse:
+    ctx = req.context
+    finding = ctx.get("finding", {})
+    cond = ctx.get("condition", {})
+    ancestors = ctx.get("ancestors", [])
+    limits = req.limits or {}
+    max_fanout = limits.get("max_fanout", 10)
+    max_depth_remaining = limits.get("max_depth_remaining", 0)
+
+    messages = [
+        {"role": "system", "content": SYSTEM_PROMPT.format(max_fanout=max_fanout)},
+        {
+            "role": "user",
+            "content": USER_TEMPLATE.format(
+                finding=finding,
+                text=cond.get("text", ""),
+                ancestors=ancestors,
+                max_depth_remaining=max_depth_remaining,
+                max_fanout=max_fanout,
+                schema=json.dumps(SCHEMA_JSON, ensure_ascii=False),
+            ),
+        },
+    ]
+
+    resp = openai_generate_response(
+        messages=messages,
+        model="o3",
+        reasoning_effort="high",
+        temperature=0.2,
+    )
+
+    raw = str(resp)
+    try:
+        text = resp.output_text
+    except Exception:
+        text = raw
+
+    m = JSON_RE.search(text or "")
+    structured = {}
+    if m:
+        try:
+            structured = json.loads(m.group(0))
+        except Exception:
+            structured = {}
+    status = structured.get("status") or "UNKNOWN"
+    final = structured.get("final") or ""
+
+    return NLResponse(
+        output=json.dumps(structured) if structured else text,
+        meta={"structured": structured, "raw": raw},
+    )
+
+__all__ = ["run"]

--- a/auditor/cli/main.py
+++ b/auditor/cli/main.py
@@ -7,6 +7,7 @@ import sys
 
 from auditor.agent import shell_agent
 from auditor.agent.random_agent import RandomAgent
+from auditor.agent import llm_agent
 from auditor.core.models import Condition, Finding
 from auditor.core.orchestrator import Orchestrator
 from auditor.report.render import _tag, render_report_json, render_report_text
@@ -25,6 +26,12 @@ def main() -> None:
         help="Disable DISCOVER calls when status is UNKNOWN",
     )
     parser.add_argument("--random", action="store_true", help="Use random agent")
+    parser.add_argument(
+        "--agent",
+        choices=["shell", "llm"],
+        default="shell",
+        help="Which non-random agent to use",
+    )
     parser.add_argument("--seed", type=int, help="Seed for random agent")
     parser.add_argument("--findings", type=int, default=1, help="Number of initial findings")
     parser.add_argument("--no-stream", action="store_true", help="Disable live event stream")
@@ -87,7 +94,10 @@ def main() -> None:
             findings.append(f)
         on_event = None if args.no_stream else printer
     else:
-        agent = shell_agent.run
+        if args.agent == "llm":
+            agent = llm_agent.run
+        else:
+            agent = shell_agent.run
         f = Finding(claim="placeholder", origin_file="")
         f.root_conditions.append(Condition(text="stub"))
         findings = [f]

--- a/tests/test_llm_agent.py
+++ b/tests/test_llm_agent.py
@@ -1,0 +1,31 @@
+import asyncio
+
+from auditor.agent.interface import NLRequest, NLResponse
+from auditor.core.models import Condition, Finding
+from auditor.core.orchestrator import Orchestrator
+
+
+async def structured_agent(req: NLRequest) -> NLResponse:
+    structured = {
+        "status": "UNKNOWN",
+        "final": "need more evidence",
+        "children": ["sub1", "sub2"],
+        "next_tasks": [{"kind": "RETRIEVE", "objective": "check details"}],
+        "notes": ""
+    }
+    # Ensure limits are passed through
+    assert "max_depth_remaining" in req.limits
+    assert "max_fanout" in req.limits
+    return NLResponse(output="ignored", meta={"structured": structured})
+
+
+def test_orchestrator_uses_structured_fields():
+    finding = Finding(claim="claim", origin_file="orig")
+    finding.root_conditions.append(Condition(text="root"))
+    orch = Orchestrator(structured_agent, max_depth=1)
+    asyncio.run(orch.run([finding]))
+    root = finding.root_conditions[0]
+    assert root.plan_params["status"] == "UNKNOWN"
+    assert root.plan_params["final"] == "need more evidence"
+    assert root.plan_params["next_tasks"] == [{"kind": "RETRIEVE", "objective": "check details"}]
+    assert [c.text for c in root.children] == ["sub1", "sub2"]


### PR DESCRIPTION
## Summary
- add llm_agent that prompts OpenAI for structured JSON judgments and tasks
- route orchestrator decisions through model-supplied status, children, and next tasks
- expose `--agent` flag in CLI for selecting llm agent

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68980c6dcb548324a6778df215c49fd7