### PR TITLE
chore: remove request limits

### DIFF
--- a/auditor/agent/interface.py
+++ b/auditor/agent/interface.py
@@ -6,7 +6,6 @@ class NLRequest(BaseModel):
     kind: str = "RETRIEVE"
     objective: str
     context: Dict[str, Any] = {}
-    limits: Dict[str, Any] = {}
 
 
 class NLResponse(BaseModel):

--- a/auditor/agent/llm_agent.py
+++ b/auditor/agent/llm_agent.py
@@ -15,7 +15,6 @@ Output STRICT JSON exactly matching the provided schema. No extra text.
 Rules:
 - status ∈ {SATISFIED, VIOLATED, UNKNOWN}
 - Keep final concise, evidence-focused.
-- Max children = {max_fanout}; omit if not needed.
 - Prefer 0 children when status ≠ UNKNOWN.
 """
 
@@ -28,9 +27,6 @@ Condition:
 
 Ancestors (shallow summaries ok):
 {ancestors}
-
-Limits:
-max_depth_remaining={max_depth_remaining}, max_fanout={max_fanout}
 
 Schema:
 {schema}
@@ -52,20 +48,15 @@ async def run(req: NLRequest) -> NLResponse:
     finding = ctx.get("finding", {})
     cond = ctx.get("condition", {})
     ancestors = ctx.get("ancestors", [])
-    limits = req.limits or {}
-    max_fanout = limits.get("max_fanout", 10)
-    max_depth_remaining = limits.get("max_depth_remaining", 0)
 
     messages = [
-        {"role": "system", "content": SYSTEM_PROMPT.format(max_fanout=max_fanout)},
+        {"role": "system", "content": SYSTEM_PROMPT},
         {
             "role": "user",
             "content": USER_TEMPLATE.format(
                 finding=finding,
                 text=cond.get("text", ""),
                 ancestors=ancestors,
-                max_depth_remaining=max_depth_remaining,
-                max_fanout=max_fanout,
                 schema=json.dumps(SCHEMA_JSON, ensure_ascii=False),
             ),
         },

--- a/auditor/core/orchestrator.py
+++ b/auditor/core/orchestrator.py
@@ -69,10 +69,6 @@ class Orchestrator:
                 "condition": _to_dict(cond),
                 "ancestors": [_to_dict(a) for a in ancestors],
             },
-            limits={
-                "max_depth_remaining": self.max_depth - depth,
-                "max_fanout": self.max_fanout,
-            },
         )
         try:
             res = await self.agent_run(req)

--- a/tests/test_llm_agent.py
+++ b/tests/test_llm_agent.py
@@ -13,9 +13,6 @@ async def structured_agent(req: NLRequest) -> NLResponse:
         "next_tasks": [{"kind": "RETRIEVE", "objective": "check details"}],
         "notes": ""
     }
-    # Ensure limits are passed through
-    assert "max_depth_remaining" in req.limits
-    assert "max_fanout" in req.limits
     return NLResponse(output="ignored", meta={"structured": structured})
 
 


### PR DESCRIPTION
## Summary
- drop limits field from `NLRequest`
- strip max_depth/max_fanout handling from LLM agent and orchestrator
- update test harness for new minimal request API

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68980ecf51c88324ae63de36a9c073e1